### PR TITLE
add redeemedPromoCodes

### DIFF
--- a/tap_stripe/schemas/subscriptions.schema.json
+++ b/tap_stripe/schemas/subscriptions.schema.json
@@ -946,6 +946,12 @@
                     "string"
                   ]
                 },
+                "redeemedPromoCodes": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
                 "type": {
                   "type": [
                     "null",


### PR DESCRIPTION
this field is integral to determining if a subscription event should be labeled as a gift subscription, and its absence was causing a bug where all gift subs were being labeled as regular subscriptions.