### PR TITLE
Give dispute stream a 90-day lookback window.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /config.json
 /.meltano/
 /.secrets/config.json
+.python-version
+.vscode/


### PR DESCRIPTION
This PR increases the lookback window for the `disputes` stream to 90 days, from 1 day.
This was done because we are fetching dispute objects, not events, from the Stripe stream, so we are not capturing updates to the dispute objects by using a 1-day lookback. By increasing the lookback window, we will capture updates to any dispute objects created in the last 90 days.

## Tests

Executed the tap through the meltano project with:
`meltano --environment=dev elt tap-stripe target-jsonl --job_id=elt-stripe-to-json --select disputes`

Saw results going back to `Friday, October 27, 2023 11:13:33 PM` in the JSON output.

Execution took under 25 seconds:

<img width="1366" alt="image" src="https://github.com/prratek/tap-stripe/assets/35661883/cb16d1bf-5eb8-44c1-b019-63f73ec68a79">
...
<img width="1365" alt="image" src="https://github.com/prratek/tap-stripe/assets/35661883/f077de3e-532f-4d76-a610-8c879880ee8c">
