### PR TITLE
Add Checkout Sessions stream.

### DIFF
--- a/tap_stripe/schemas/checkout-sessions.schema.json
+++ b/tap_stripe/schemas/checkout-sessions.schema.json
@@ -1,0 +1,620 @@
+{
+  "type": [
+    "null",
+    "object"
+  ],
+  "properties": {
+    "id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "object": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "api_version": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "created": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "data": {
+      "properties": {
+        "object": {
+          "properties": {
+            "id": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "object": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "billing": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "billing_thresholds": {
+              "properties": {
+                "amount_gte": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "reset_billing_cycle_anchor": {
+                  "type": [
+                    "null",
+                    "boolean"
+                  ]
+                }
+              },
+              "type": [
+                "null",
+                "object"
+              ]
+            },
+            "canceled_at": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "collection_method": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "completed_at": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "created": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "current_phase": {
+              "properties": {
+                "end_date": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "start_date": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                }
+              },
+              "type": [
+                "null",
+                "object"
+              ]
+            },
+            "customer": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "default_payment_method": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "default_settings": {
+              "properties": {
+                "application_fee_percent": {
+                  "type": [
+                    "null",
+                    "number"
+                  ]
+                },
+                "billing_cycle_anchor": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "billing_thresholds": {
+                  "properties": {
+                    "amount_gte": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    },
+                    "reset_billing_cycle_anchor": {
+                      "type": [
+                        "null",
+                        "boolean"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "null",
+                    "object"
+                  ]
+                },
+                "collection_method": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "default_payment_method": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "default_source": {
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "invoice_settings": {
+                  "properties": {
+                    "days_until_due": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "null",
+                    "object"
+                  ]
+                },
+                "transfer_data": {
+                  "properties": {
+                    "amount_percent": {
+                      "type": [
+                        "null",
+                        "number"
+                      ]
+                    },
+                    "destination": {
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "null",
+                    "object"
+                  ]
+                }
+              },
+              "type": [
+                "null",
+                "object"
+              ]
+            },
+            "default_source": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "end_behavior": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "invoice_settings": {
+              "properties": {
+                "days_until_due": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                }
+              },
+              "type": [
+                "null",
+                "object"
+              ]
+            },
+            "livemode": {
+              "type": [
+                "null",
+                "boolean"
+              ]
+            },
+            "phases": {
+              "items": {
+                "properties": {
+                  "application_fee_percent": {
+                    "type": [
+                      "null",
+                      "number"
+                    ]
+                  },
+                  "billing_cycle_anchor": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "billing_thresholds": {
+                    "properties": {
+                      "amount_gte": {
+                        "type": [
+                          "null",
+                          "integer"
+                        ]
+                      },
+                      "reset_billing_cycle_anchor": {
+                        "type": [
+                          "null",
+                          "boolean"
+                        ]
+                      }
+                    },
+                    "type": [
+                      "null",
+                      "object"
+                    ]
+                  },
+                  "collection_method": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "coupon": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "default_payment_method": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "end_date": {
+                    "type": [
+                      "null",
+                      "integer"
+                    ]
+                  },
+                  "invoice_settings": {
+                    "properties": {
+                      "days_until_due": {
+                        "type": [
+                          "null",
+                          "integer"
+                        ]
+                      }
+                    },
+                    "type": [
+                      "null",
+                      "object"
+                    ]
+                  },
+                  "plans": {
+                    "items": {
+                      "properties": {
+                        "billing_thresholds": {
+                          "properties": {
+                            "amount_gte": {
+                              "type": [
+                                "null",
+                                "integer"
+                              ]
+                            },
+                            "reset_billing_cycle_anchor": {
+                              "type": [
+                                "null",
+                                "boolean"
+                              ]
+                            }
+                          },
+                          "type": [
+                            "null",
+                            "object"
+                          ]
+                        },
+                        "plan": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "price": {
+                          "type": [
+                            "null",
+                            "string"
+                          ]
+                        },
+                        "quantity": {
+                          "type": [
+                            "null",
+                            "integer"
+                          ]
+                        }
+                      },
+                      "type": [
+                        "null",
+                        "object"
+                      ]
+                    },
+                    "type": [
+                      "null",
+                      "array"
+                    ]
+                  },
+                  "prorate": {
+                    "type": [
+                      "null",
+                      "boolean"
+                    ]
+                  },
+                  "proration_behavior": {
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
+                  "start_date": {
+                    "type": [
+                      "null",
+                      "integer"
+                    ]
+                  },
+                  "tax_percent": {
+                    "type": [
+                      "null",
+                      "number"
+                    ]
+                  },
+                  "transfer_data": {
+                    "properties": {
+                      "amount_percent": {
+                        "type": [
+                          "null",
+                          "number"
+                        ]
+                      },
+                      "destination": {
+                        "type": [
+                          "null",
+                          "string"
+                        ]
+                      }
+                    },
+                    "type": [
+                      "null",
+                      "object"
+                    ]
+                  },
+                  "trial_end": {
+                    "type": [
+                      "null",
+                      "integer"
+                    ]
+                  }
+                },
+                "type": [
+                  "null",
+                  "object"
+                ]
+              },
+              "type": [
+                "null",
+                "array"
+              ]
+            },
+            "released_at": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "released_subscription": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "renewal_behavior": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "renewal_interval": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "status": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "subscription": {
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          },
+          "type": [
+            "null",
+            "object"
+          ]
+        },
+        "previous_attributes": {
+          "properties": {
+            "default_settings": {
+              "properties": {
+                "invoice_settings": {
+                  "properties": {
+                    "days_until_due": {
+                      "type": [
+                        "null",
+                        "integer"
+                      ]
+                    }
+                  },
+                  "type": [
+                    "null",
+                    "object"
+                  ]
+                }
+              },
+              "type": [
+                "null",
+                "object"
+              ]
+            },
+            "invoice_settings": {
+              "properties": {
+                "days_until_due": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                }
+              },
+              "type": [
+                "null",
+                "object"
+              ]
+            },
+            "current_phase": {
+              "properties": {
+                "end_date": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                },
+                "start_date": {
+                  "type": [
+                    "null",
+                    "integer"
+                  ]
+                }
+              },
+              "type": [
+                "null",
+                "object"
+              ]
+            },
+            "released_at": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "released_subscription": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "status": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "subscription": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "canceled_at": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            }
+          },
+          "type": [
+            "null",
+            "object"
+          ]
+        }
+      },
+      "type": [
+        "null",
+        "object"
+      ]
+    },
+    "livemode": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "pending_webhooks": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "request": {
+      "properties": {
+        "id": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "idempotency_key": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      },
+      "type": [
+        "null",
+        "object"
+      ]
+    },
+    "type": {
+      "type": [
+        "null",
+        "string"
+      ]
+    }
+  }
+}

--- a/tap_stripe/streams.py
+++ b/tap_stripe/streams.py
@@ -17,6 +17,7 @@ SCHEMAS_DIR = Path(__file__).parent / Path("./schemas")
 SDK_OBJECTS = {
     "balance_transactions": stripe.BalanceTransaction,
     "charges": stripe.Charge,
+    "checkout_sessions": stripe.checkout.Session,
     "coupons": stripe.Coupon,
     "customers": stripe.Customer,
     "disputes": stripe.Dispute,
@@ -53,6 +54,7 @@ EVENT_TYPE_FILTERS = {
     "payouts": {"type": "payout.*"},
     "plans": {"type": "plan.*"},
     "promotion_codes": {"type": "promotion_code.*"},
+    "checkout_sessions": {"type": "checkout.session.*"},
     "subscription_schedules": {"type": "subscription_schedule.*"},
     "subscriptions": {"type": "customer.subscription.*"},
 }
@@ -182,6 +184,15 @@ class ChargesStream(StripeStream):
     primary_keys = ["id"]
     replication_key = "created"
     schema_filepath = SCHEMAS_DIR / "charges.schema.json"
+
+
+class CheckoutSessionsStream(StripeStream):
+    """Stripe Checkout Sessions stream."""
+
+    name = "checkout_sessions"
+    primary_keys = ["id"]
+    replication_key = "created"
+    schema_filepath = SCHEMAS_DIR / "checkout-sessions.schema.json"
 
 
 class CouponsStream(StripeStream):

--- a/tap_stripe/tap.py
+++ b/tap_stripe/tap.py
@@ -8,6 +8,7 @@ from singer_sdk.typing import DateTimeType, PropertiesList, Property, StringType
 from tap_stripe.streams import (
     BalanceTransactionsStream,
     ChargesStream,
+    CheckoutSessionsStream,
     CouponsStream,
     CustomersStream,
     DiscountsStream,
@@ -24,6 +25,7 @@ from tap_stripe.streams import (
 STREAM_TYPES = [
     BalanceTransactionsStream,
     ChargesStream,
+    CheckoutSessionsStream,
     CouponsStream,
     CustomersStream,
     DiscountsStream,


### PR DESCRIPTION
Added support for the checkout sessions stream, including all checkout sessions events.

## Testing

Meltano job ran successfully.
Sample data exists in `nymag-analytics-157315.dev_meltano.dev_checkout_sessions`.

## Follow-Up

Merge the PR to actually add this to the dagster job.